### PR TITLE
Spotify/wrapper

### DIFF
--- a/cmd/telegram/main.go
+++ b/cmd/telegram/main.go
@@ -16,7 +16,7 @@ func main() {
 	authConf := &oauth2.Config{
 		ClientID:     config.AppConfig.Spotify.SpotifyClientID,
 		ClientSecret: config.AppConfig.Spotify.SpotifyClientSecret,
-		Scopes:       []string{"user-read-playback-state"},
+		Scopes:       []string{"user-read-currently-playing"},
 		Endpoint:     spotifyOauth.Endpoint,
 		RedirectURL:  "http://" + config.AppConfig.Webserver.Address + "/auth/callback", //FIXME
 	}

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -18,7 +18,9 @@ func main() {
 	mongoStorage, err := mongo.NewMongoStorage(ctx, mongo.MongoStorageOptions{
 		DSN: config.AppConfig.Webserver.MongoDSN,
 	})
-
+	if err != nil {
+		log.Fatalf("Failed to connect to Mongo Storage", err)
+	}
 	authConf := &oauth2.Config{
 		ClientID:     config.AppConfig.Spotify.SpotifyClientID,
 		ClientSecret: config.AppConfig.Spotify.SpotifyClientSecret,

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -6,9 +6,10 @@ import (
 
 	"github.com/koskalak/mamal/internal/config"
 	"github.com/koskalak/mamal/internal/mongo"
+	"github.com/koskalak/mamal/internal/spotify"
 	"github.com/koskalak/mamal/internal/webserver"
 	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/spotify"
+	spotifyOauth "golang.org/x/oauth2/spotify"
 )
 
 func main() {
@@ -22,13 +23,17 @@ func main() {
 		ClientID:     config.AppConfig.Spotify.SpotifyClientID,
 		ClientSecret: config.AppConfig.Spotify.SpotifyClientSecret,
 		Scopes:       []string{"user-read-playback-state"},
-		Endpoint:     spotify.Endpoint,
+		Endpoint:     spotifyOauth.Endpoint,
 		RedirectURL:  "http://" + config.AppConfig.Webserver.Address + "/auth/callback", //FIXME
 	}
 
-	w := webserver.New(webserver.WebServerOptions{
-		Mongo:      mongoStorage,
+	s := spotify.New(spotify.ProviderOptions{
+		Db:         mongoStorage,
 		AuthConfig: authConf,
+	})
+
+	w := webserver.New(webserver.WebServerOptions{
+		Spotify: s,
 	})
 
 	err = w.Start(config.AppConfig.Webserver.Address)

--- a/cmd/webserver/main.go
+++ b/cmd/webserver/main.go
@@ -17,7 +17,7 @@ func main() {
 	authConf := &oauth2.Config{
 		ClientID:     config.AppConfig.Spotify.SpotifyClientID,
 		ClientSecret: config.AppConfig.Spotify.SpotifyClientSecret,
-		Scopes:       []string{"user-read-playback-state"},
+		Scopes:       []string{"user-read-currently-playing"},
 		Endpoint:     spotifyOauth.Endpoint,
 		RedirectURL:  "http://" + config.AppConfig.Webserver.Address + "/auth/callback", //FIXME
 	}

--- a/internal/mongo/mongo.go
+++ b/internal/mongo/mongo.go
@@ -50,6 +50,8 @@ type OAuthToken struct {
 	ID           primitive.ObjectID `bson:"_id,omitempty"`
 	AccessToken  string             `bson:"access_token"`
 	RefreshToken string             `bson:"refresh_token"`
+	TokenType    string             `bson:"token_type"`
+	Expiry       time.Time          `bson:"expiry"`
 	UserID       string             `bson:"user_id"`
 	Platform     string             `bson:"platform"`
 }

--- a/internal/mongo/mongo.go
+++ b/internal/mongo/mongo.go
@@ -13,12 +13,6 @@ import (
 
 const OAuthTokenCollection = "oauth_tokens"
 
-type oauthPlatform string
-
-const (
-	PlatformTelegram oauthPlatform = "telegram"
-)
-
 type MongoStorageOptions struct {
 	DSN string
 }
@@ -57,7 +51,7 @@ type OAuthToken struct {
 	AccessToken  string             `bson:"access_token"`
 	RefreshToken string             `bson:"refresh_token"`
 	UserID       string             `bson:"user_id"`
-	Platform     oauthPlatform      `bson:"platform"`
+	Platform     string             `bson:"platform"`
 }
 
 func (m *MongoStorage) UpsertOAuthToken(ctx context.Context, token OAuthToken) error {
@@ -78,7 +72,7 @@ func (m *MongoStorage) UpsertOAuthToken(ctx context.Context, token OAuthToken) e
 	return nil
 }
 
-func (m *MongoStorage) GetOAuthTokenByUserID(ctx context.Context, userID string, platform oauthPlatform) (*OAuthToken, error) {
+func (m *MongoStorage) GetOAuthTokenByUserID(ctx context.Context, userID string, platform string) (*OAuthToken, error) {
 	collection := m.database.Collection(OAuthTokenCollection)
 
 	filter := bson.D{

--- a/internal/platform/telegram/bot.go
+++ b/internal/platform/telegram/bot.go
@@ -4,22 +4,30 @@ import (
 	"log"
 
 	"github.com/koskalak/mamal/internal/config"
+	"github.com/koskalak/mamal/internal/spotify"
 	tgbotapi "github.com/mohammadkarimi23/telegram-bot-api/v5"
 	"strconv"
 )
 
 type TGBot struct {
-	bot *tgbotapi.BotAPI
+	bot     *tgbotapi.BotAPI
+	spotify *spotify.SpotifyProvider
 }
 
-func New(token string) *TGBot {
-	bot, err := tgbotapi.NewBotAPI(token) //FIXME change to use configs
+type TGBotOptions struct {
+	Token           string
+	SpotifyProvider *spotify.SpotifyProvider
+}
+
+func New(opts TGBotOptions) *TGBot {
+	bot, err := tgbotapi.NewBotAPI(opts.Token) //FIXME change to use configs
 	if err != nil {
 		log.Panic(err)
 	}
 	log.Printf("Authorized on account %s", bot.Self.UserName)
 	telegramBot := TGBot{
-		bot: bot,
+		bot:     bot,
+		spotify: opts.SpotifyProvider,
 	}
 	return &telegramBot
 }

--- a/internal/platform/telegram/bot.go
+++ b/internal/platform/telegram/bot.go
@@ -90,7 +90,7 @@ func (tb *TGBot) processInlineQuery(update *tgbotapi.Update) {
 		CacheTime:     0,
 	}
 
-	rp, err := tb.spotify.GetRecentlyPlayed("telegram", strconv.Itoa(update.InlineQuery.From.ID))
+	rp, err := tb.spotify.GetRecentlyPlayed(spotify.PlatformTelegram, strconv.Itoa(update.InlineQuery.From.ID))
 	if err != nil { //If not logged in, show the log in keyboard button
 		log.Println("Failed to get recently played song", err)
 		inlineConf.SwitchPMText = "Login to Spotify"

--- a/internal/platform/telegram/bot.go
+++ b/internal/platform/telegram/bot.go
@@ -97,7 +97,7 @@ func (tb *TGBot) processInlineQuery(update *tgbotapi.Update) {
 		inlineConf.SwitchPMParameter = "auth"
 	} else {
 		songLink := spotify.OpenSpotifyTrackEndpoint + rp.ID
-		article := getTrackQueryResult(update.InlineQuery.ID, "kir", songLink, songLink)
+		article := getTrackQueryResult(update.InlineQuery.ID, rp.Name, songLink, songLink)
 		inlineConf.Results = []interface{}{article}
 	}
 

--- a/internal/platform/telegram/bot.go
+++ b/internal/platform/telegram/bot.go
@@ -84,6 +84,13 @@ func (tb *TGBot) processDirectMessage(update *tgbotapi.Update) {
 
 func (tb *TGBot) processInlineQuery(update *tgbotapi.Update) {
 
+	rp, err := tb.spotify.GetRecentlyPlayed("telegram", strconv.Itoa(update.InlineQuery.From.ID))
+	if err != nil {
+		log.Println("Failed to get recently played song", err)
+	} else {
+		log.Println("Here comes the result: ", spotify.OpenSpotifyTrackEndpoint+rp.ID)
+	}
+
 	article := tgbotapi.NewInlineQueryResultArticle(update.InlineQuery.ID, "Echo", update.InlineQuery.Query)
 	article.Description = update.InlineQuery.Query
 

--- a/internal/platform/telegram/markup.go
+++ b/internal/platform/telegram/markup.go
@@ -14,3 +14,15 @@ func getAuthMessage(userID string) tgbotapi.InlineKeyboardMarkup {
 		),
 	)
 }
+
+func getTrackQueryResult(id, title, url, messageText string) tgbotapi.InlineQueryResultArticle {
+	return tgbotapi.InlineQueryResultArticle{
+		Type:  "article",
+		ID:    id,
+		Title: title,
+		URL:   url,
+		InputMessageContent: tgbotapi.InputTextMessageContent{
+			Text: messageText,
+		},
+	}
+}

--- a/internal/spotify/provider.go
+++ b/internal/spotify/provider.go
@@ -44,7 +44,7 @@ func (s *SpotifyProvider) GetAuthURL() string {
 	return s.authConfig.AuthCodeURL("state", oauth2.AccessTypeOffline)
 }
 
-func (s *SpotifyProvider) AddUser(code, platform, userID string) error {
+func (s *SpotifyProvider) AddUser(code string, platform OauthPlatform, userID string) error {
 	ctx := context.Background() //FIXME
 	token, err := s.authConfig.Exchange(ctx, code)
 	if err != nil {
@@ -59,22 +59,20 @@ func (s *SpotifyProvider) AddUser(code, platform, userID string) error {
 		RefreshToken: token.RefreshToken,
 		TokenType:    token.Type(),
 		Expiry:       token.Expiry,
-		Platform:     platform,
+		Platform:     string(platform),
 		UserID:       userID,
 	}
 	if err = s.db.UpsertOAuthToken(ctx, mongoRow); err != nil {
 		log.Println("Failed to add token to database")
 	}
 
-	//TODO strore to DB
-	log.Println("Authentication Successful!")
 	log.Printf("Code: [%s]\nPlatform: [%s]\nUser ID: [%s]", token.AccessToken, platform, userID)
 	return nil
 }
 
-func (s *SpotifyProvider) GetRecentlyPlayed(platform, userID string) (track *Item, err error) {
+func (s *SpotifyProvider) GetRecentlyPlayed(platform OauthPlatform, userID string) (track *Item, err error) {
 	ctx := context.Background()
-	mongoToken, err := s.db.GetOAuthTokenByUserID(ctx, userID, platform)
+	mongoToken, err := s.db.GetOAuthTokenByUserID(ctx, userID, string(platform))
 	if err != nil {
 		return
 	}

--- a/internal/spotify/provider.go
+++ b/internal/spotify/provider.go
@@ -8,8 +8,8 @@ import (
 )
 
 type ProviderOptions struct {
-	Db         *mongo.MongoStorage
-	AuthConfig *oauth2.Config
+	DatabaseDSN string
+	AuthConfig  *oauth2.Config
 }
 
 type SpotifyProvider struct {
@@ -17,11 +17,24 @@ type SpotifyProvider struct {
 	authConfig *oauth2.Config
 }
 
-func New(opts ProviderOptions) *SpotifyProvider {
-	return &SpotifyProvider{
-		db:         opts.Db,
-		authConfig: opts.AuthConfig,
+var provider *SpotifyProvider
+
+func New(ctx context.Context, opts ProviderOptions) (*SpotifyProvider, error) {
+	if provider != nil {
+		return provider, nil
 	}
+
+	mongoStorage, err := mongo.NewMongoStorage(ctx, mongo.MongoStorageOptions{
+		DSN: opts.DatabaseDSN,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &SpotifyProvider{
+		db:         mongoStorage,
+		authConfig: opts.AuthConfig,
+	}, nil
 }
 
 func (s *SpotifyProvider) GetAuthURL() string {

--- a/internal/spotify/provider.go
+++ b/internal/spotify/provider.go
@@ -37,8 +37,19 @@ func (s *SpotifyProvider) AddUser(code, platform, userID string) error {
 
 	client := s.authConfig.Client(ctx, token)
 	client.Get("...") //FIXME
+
+	mongoRow := mongo.OAuthToken{
+		AccessToken:  token.AccessToken,
+		RefreshToken: token.RefreshToken,
+		Platform:     platform,
+		UserID:       userID,
+	}
+	if err = s.db.UpsertOAuthToken(ctx, mongoRow); err != nil {
+		log.Println("Failed to add token to database")
+	}
+
 	//TODO strore to DB
 	log.Println("Authentication Successful!")
-	log.Println("Code: [%s]\nPlatform: [%s]\nUser ID: [%s]", code, platform, userID)
+	log.Printf("Code: [%s]\nPlatform: [%s]\nUser ID: [%s]", code, platform, userID)
 	return nil
 }

--- a/internal/spotify/provider.go
+++ b/internal/spotify/provider.go
@@ -1,0 +1,44 @@
+package spotify
+
+import (
+	"context"
+	"github.com/koskalak/mamal/internal/mongo"
+	"golang.org/x/oauth2"
+	"log"
+)
+
+type ProviderOptions struct {
+	Db         *mongo.MongoStorage
+	AuthConfig *oauth2.Config
+}
+
+type SpotifyProvider struct {
+	db         *mongo.MongoStorage
+	authConfig *oauth2.Config
+}
+
+func New(opts ProviderOptions) *SpotifyProvider {
+	return &SpotifyProvider{
+		db:         opts.Db,
+		authConfig: opts.AuthConfig,
+	}
+}
+
+func (s *SpotifyProvider) GetAuthURL() string {
+	return s.authConfig.AuthCodeURL("state", oauth2.AccessTypeOffline)
+}
+
+func (s *SpotifyProvider) AddUser(code, platform, userID string) error {
+	ctx := context.Background() //FIXME
+	token, err := s.authConfig.Exchange(ctx, code)
+	if err != nil {
+		return err
+	}
+
+	client := s.authConfig.Client(ctx, token)
+	client.Get("...") //FIXME
+	//TODO strore to DB
+	log.Println("Authentication Successful!")
+	log.Println("Code: [%s]\nPlatform: [%s]\nUser ID: [%s]", code, platform, userID)
+	return nil
+}

--- a/internal/spotify/types.go
+++ b/internal/spotify/types.go
@@ -1,0 +1,15 @@
+package spotify
+
+const (
+	OpenSpotifyTrackEndpoint = "https://open.spotify.com/track/"
+	RecentlyPlayedEndpoint   = "https://api.spotify.com/v1/me/player/currently-playing"
+)
+
+type Response struct {
+	Item Item `json:"item"`
+}
+
+type Item struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+}

--- a/internal/spotify/types.go
+++ b/internal/spotify/types.go
@@ -1,8 +1,11 @@
 package spotify
 
+type OauthPlatform string
+
 const (
-	OpenSpotifyTrackEndpoint = "https://open.spotify.com/track/"
-	RecentlyPlayedEndpoint   = "https://api.spotify.com/v1/me/player/currently-playing"
+	OpenSpotifyTrackEndpoint               = "https://open.spotify.com/track/"
+	RecentlyPlayedEndpoint                 = "https://api.spotify.com/v1/me/player/currently-playing"
+	PlatformTelegram         OauthPlatform = "telegram"
 )
 
 type Response struct {

--- a/internal/spotify/types.go
+++ b/internal/spotify/types.go
@@ -10,6 +10,7 @@ type Response struct {
 }
 
 type Item struct {
+	Name string `json:"name"`
 	ID   string `json:"id"`
 	Type string `json:"type"`
 }

--- a/internal/webserver/endpoints.go
+++ b/internal/webserver/endpoints.go
@@ -1,8 +1,6 @@
 package webserver
 
 import (
-	"context"
-	"golang.org/x/oauth2"
 	"net/http"
 	"time"
 
@@ -36,18 +34,9 @@ func (s *WebServer) SpotifyCallback(c echo.Context) error {
 	platform := platformCookie.Value
 	userID := userCookie.Value
 	authCode := c.QueryParam("code")
+	s.spotify.AddUser(authCode, platform, userID) //TODO get error
 
-	ctx := context.Background() //FIXME
-	token, err := s.authConfig.Exchange(ctx, authCode)
-	if err != nil {
-		s.server.Logger.Fatal(err)
-	}
-
-	client := s.authConfig.Client(ctx, token)
-	client.Get("...") //FIXME
-	//TODO strore to DB
-
-	return c.String(http.StatusOK, platform+"\n"+userID+"\n"+token.AccessToken)
+	return c.String(200, "Authentication Successful")
 }
 
 func (s *WebServer) TelegramAuth(c echo.Context) error {
@@ -70,7 +59,7 @@ func (s *WebServer) TelegramAuth(c echo.Context) error {
 	platformCookie.Expires = time.Now().Add(1 * time.Hour)
 	c.SetCookie(platformCookie)
 
-	url := s.authConfig.AuthCodeURL("state", oauth2.AccessTypeOffline)
+	url := s.spotify.GetAuthURL()
 	c.Redirect(http.StatusFound, url)
 	return nil
 }

--- a/internal/webserver/endpoints.go
+++ b/internal/webserver/endpoints.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/koskalak/mamal/internal/spotify"
 	"github.com/labstack/echo/v4"
 )
 
@@ -31,10 +32,18 @@ func (s *WebServer) SpotifyCallback(c echo.Context) error {
 	if err != nil {
 		s.server.Logger.Panic(err)
 	}
-	platform := platformCookie.Value
+
+	var oathPlatform spotify.OauthPlatform
+	switch platform := platformCookie.Value; platform {
+	case "telegram":
+		oathPlatform = spotify.PlatformTelegram
+	default:
+		s.server.Logger.Panic("Unsupported Platform")
+	}
+
 	userID := userCookie.Value
 	authCode := c.QueryParam("code")
-	s.spotify.AddUser(authCode, platform, userID) //TODO get error
+	s.spotify.AddUser(authCode, oathPlatform, userID) //TODO get error
 
 	return c.String(200, "Authentication Successful")
 }

--- a/internal/webserver/server.go
+++ b/internal/webserver/server.go
@@ -1,21 +1,18 @@
 package webserver
 
 import (
-	"github.com/koskalak/mamal/internal/mongo"
+	"github.com/koskalak/mamal/internal/spotify"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
-	"golang.org/x/oauth2"
 )
 
 type WebServerOptions struct {
-	Mongo      *mongo.MongoStorage
-	AuthConfig *oauth2.Config
+	Spotify *spotify.SpotifyProvider
 }
 
 type WebServer struct {
-	server     *echo.Echo
-	mongo      *mongo.MongoStorage
-	authConfig *oauth2.Config
+	server  *echo.Echo
+	spotify *spotify.SpotifyProvider
 }
 
 func New(opts WebServerOptions) *WebServer {
@@ -25,9 +22,8 @@ func New(opts WebServerOptions) *WebServer {
 	e.Use(middleware.Recover())
 
 	webServer := &WebServer{
-		server:     e,
-		mongo:      opts.Mongo,
-		authConfig: opts.AuthConfig,
+		server:  e,
+		spotify: opts.Spotify,
 	}
 
 	e.GET("/", webServer.Index)


### PR DESCRIPTION
Spotify Provider provides the functionality required for the platform.

The biggest downfall to the current design is using Spotify package functionalities by function calls. this has created a lot of boilerplating and redundant coupling of telegram to oauth2 functionalities.
This can be solved by embedding spotify package functionalities into webserver (having grpc connections between platform and webserver can be a good idea). this gives a lot of flexibility for developing and supporting extra features from different messaging platforms